### PR TITLE
included pglearn correlated load perturbations

### DIFF
--- a/GridDataGen/utils/param_handler.py
+++ b/GridDataGen/utils/param_handler.py
@@ -132,6 +132,7 @@ def get_load_scenario_generator(args) -> LoadScenarioGeneratorBase:
     if args.load.generator == "correlated_scaler":
         return LoadScenariosFromCorrelatedScaling(
             args.load.sigma,
-            args.load.upper_limit,
-            args.load.lower_limit,
-    )
+            args.load.global_range,
+            args.load.max_scaling_factor,
+            args.load.step_size,
+            args.load.start_scaling_factor)

--- a/GridDataGen/utils/param_handler.py
+++ b/GridDataGen/utils/param_handler.py
@@ -128,3 +128,10 @@ def get_load_scenario_generator(args) -> LoadScenarioGeneratorBase:
         )
     if args.load.generator == "powergraph":
         return Powergraph(args.load.agg_profile)
+    
+    if args.load.generator == "correlated_scaler":
+        return LoadScenariosFromCorrelatedScaling(
+            args.load.sigma,
+            args.load.upper_limit,
+            args.load.lower_limit,
+    )

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ python dist_generate_pf_data.py --config path/to/config.yaml --data_path /path/t
 |                          | `max_scaling_factor`         | float    | Max upper bound of the global scaling factor. Used when `generator` is `agg_load_profile`.        |
 |                          | `step_size`                  | float    | Step size when finding the upper bound of the global scaling factor. Used when `generator` is `agg_load_profile`. |
 |                          | `start_scaling_factor`       | float    | Initial value of the global scaling factor. Used when `generator` is `agg_load_profile`.          |
-|                          | `upper_limit`       | float    | Global upper bound for grid. Used when `generator` is `correlated_scaler`.          |
-|                          | `lower_limit`       | float    | Global lower bound for grid. Used when `generator` is `correlated_scaler`.          |
 | **topology_perturbation**| `type`                       | str      | Type of topology generator; options: `n_minus_k`, `random`, `overloaded`, `none`.                  |
 |                          | `k`                          | int      | Maximum number of components to drop in each perturbation; used when `type` is `n_minus_k` or `random`. |
 |                          | `n_topology_variants`        | int      | Number of unique perturbed topologies per scenario; used when `type` is `n_minus_k`, `random`, or `overloaded`. |

--- a/README.md
+++ b/README.md
@@ -54,15 +54,17 @@ python dist_generate_pf_data.py --config path/to/config.yaml --data_path /path/t
 |--------------------------|------------------------------|----------|-----------------------------------------------------------------------------------------------------|
 | **network**              | `name`                       | str      | Name of the power grid network.                                                                     |
 |                          | `source`                     | str      | Data source for the grid; options: `pglib`, `pandapower`, `file`.                                  |
-| **load**                 | `generator`                  | str      | Name of the load generator; options: `agg_load_profile`, `powergraph`.                             |
+| **load**                 | `generator`                  | str      | Name of the load generator; options: `agg_load_profile`, `powergraph`, `correlated_scaler`.                             |
 |                          | `agg_profile`                | str      | Name of the aggregated load profile; used when `generator` is `agg_load_profile`.                   |
 |                          | `scenarios`                  | int      | Number of different load scenarios to generate.                                                     |
-|                          | `sigma`                      | float    | Max local noise; used when `generator` is `agg_load_profile`.                                     |
+|                          | `sigma`                      | float    | Max local noise; used when `generator` is `agg_load_profile` or `correlated_scaler`.                                     |
 |                          | `change_reactive_power`      | bool     | If true, changes reactive power of loads. If false, keeps the ones from the case file. Used when `generator` is `agg_load_profile`. |
 |                          | `global_range`               | float    | Range of the global scaling factor. Used to set the lower bound of the scaling factor. Used when `generator` is `agg_load_profile`. |
 |                          | `max_scaling_factor`         | float    | Max upper bound of the global scaling factor. Used when `generator` is `agg_load_profile`.        |
 |                          | `step_size`                  | float    | Step size when finding the upper bound of the global scaling factor. Used when `generator` is `agg_load_profile`. |
 |                          | `start_scaling_factor`       | float    | Initial value of the global scaling factor. Used when `generator` is `agg_load_profile`.          |
+|                          | `upper_limit`       | float    | Global upper bound for grid. Used when `generator` is `correlated_scaler`.          |
+|                          | `lower_limit`       | float    | Global lower bound for grid. Used when `generator` is `correlated_scaler`.          |
 | **topology_perturbation**| `type`                       | str      | Type of topology generator; options: `n_minus_k`, `random`, `overloaded`, `none`.                  |
 |                          | `k`                          | int      | Maximum number of components to drop in each perturbation; used when `type` is `n_minus_k` or `random`. |
 |                          | `n_topology_variants`        | int      | Number of unique perturbed topologies per scenario; used when `type` is `n_minus_k`, `random`, or `overloaded`. |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python dist_generate_pf_data.py --config path/to/config.yaml --data_path /path/t
 |                          | `change_reactive_power`      | bool     | If true, changes reactive power of loads. If false, keeps the ones from the case file. Used when `generator` is `agg_load_profile`. |
 |                          | `global_range`               | float    | Range of the global scaling factor. Used to set the lower bound of the scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`. |
 |                          | `max_scaling_factor`         | float    | Max upper bound of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`.        |
-|                          | `step_size`                  | float    | Step size when finding the upper bound of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`. |
+|                          | `step_size`                  | float    | Step size when finding the upper bound of the global scaling factor. Used when `generator` is `agg_load_profile` or. |
 |                          | `start_scaling_factor`       | float    | Initial value of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`.          |
 | **topology_perturbation**| `type`                       | str      | Type of topology generator; options: `n_minus_k`, `random`, `overloaded`, `none`.                  |
 |                          | `k`                          | int      | Maximum number of components to drop in each perturbation; used when `type` is `n_minus_k` or `random`. |

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ python dist_generate_pf_data.py --config path/to/config.yaml --data_path /path/t
 |                          | `scenarios`                  | int      | Number of different load scenarios to generate.                                                     |
 |                          | `sigma`                      | float    | Max local noise; used when `generator` is `agg_load_profile` or `correlated_scaler`.                                     |
 |                          | `change_reactive_power`      | bool     | If true, changes reactive power of loads. If false, keeps the ones from the case file. Used when `generator` is `agg_load_profile`. |
-|                          | `global_range`               | float    | Range of the global scaling factor. Used to set the lower bound of the scaling factor. Used when `generator` is `agg_load_profile`. |
-|                          | `max_scaling_factor`         | float    | Max upper bound of the global scaling factor. Used when `generator` is `agg_load_profile`.        |
-|                          | `step_size`                  | float    | Step size when finding the upper bound of the global scaling factor. Used when `generator` is `agg_load_profile`. |
-|                          | `start_scaling_factor`       | float    | Initial value of the global scaling factor. Used when `generator` is `agg_load_profile`.          |
+|                          | `global_range`               | float    | Range of the global scaling factor. Used to set the lower bound of the scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`. |
+|                          | `max_scaling_factor`         | float    | Max upper bound of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`.        |
+|                          | `step_size`                  | float    | Step size when finding the upper bound of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`. |
+|                          | `start_scaling_factor`       | float    | Initial value of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`.          |
 | **topology_perturbation**| `type`                       | str      | Type of topology generator; options: `n_minus_k`, `random`, `overloaded`, `none`.                  |
 |                          | `k`                          | int      | Maximum number of components to drop in each perturbation; used when `type` is `n_minus_k` or `random`. |
 |                          | `n_topology_variants`        | int      | Number of unique perturbed topologies per scenario; used when `type` is `n_minus_k`, `random`, or `overloaded`. |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ python dist_generate_pf_data.py --config path/to/config.yaml --data_path /path/t
 |                          | `change_reactive_power`      | bool     | If true, changes reactive power of loads. If false, keeps the ones from the case file. Used when `generator` is `agg_load_profile`. |
 |                          | `global_range`               | float    | Range of the global scaling factor. Used to set the lower bound of the scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`. |
 |                          | `max_scaling_factor`         | float    | Max upper bound of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`.        |
-|                          | `step_size`                  | float    | Step size when finding the upper bound of the global scaling factor. Used when `generator` is `agg_load_profile` or. |
+|                          | `step_size`                  | float    | Step size when finding the upper bound of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`. |
 |                          | `start_scaling_factor`       | float    | Initial value of the global scaling factor. Used when `generator` is `agg_load_profile` or `correlated_scaler`.          |
 | **topology_perturbation**| `type`                       | str      | Type of topology generator; options: `n_minus_k`, `random`, `overloaded`, `none`.                  |
 |                          | `k`                          | int      | Maximum number of components to drop in each perturbation; used when `type` is `n_minus_k` or `random`. |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nbformat
 matplotlib
-pandapower
+pandapower==2.14.10
 plotly
 pandas
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pathlib
 matpowercaseframes
 numba
 requests
+PyYAML

--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -3,7 +3,7 @@ network:
   source: "pglib" # Data source for the grid; options: pglib, pandapower, file
 
 load:
-  generator: "agg_load_profile" # Name of the load generator
+  generator: "correlated_scaler" # Name of the load generator
   agg_profile: "powergraph_ieee118" # Name of the aggregated load profile
   scenarios: 15000 # Number of different load scenarios to generate
   sigma: 0.05 # max local noise 
@@ -12,6 +12,8 @@ load:
   max_scaling_factor: 4.0 # Max upper bound of the global scaling factor
   step_size: 0.025 # Step size when finding the upper bound of the global scaling factor
   start_scaling_factor: 0.8 # Initial value of the global scaling factor
+  upper_limit : 1.68 # Global upper bound
+  lower_limit : 0.86 # Global lower bound 
 
 topology_perturbation:
   k: 10 # Maximum number of components to drop in each perturbation

--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -6,15 +6,13 @@ load:
   generator: "correlated_scaler" # Name of the load generator
   agg_profile: "powergraph_ieee118" # Name of the aggregated load profile
   scenarios: 15000 # Number of different load scenarios to generate
-  sigma: 0.05 # max local noise 
+  sigma: 0.15 # max local noise 
   change_reactive_power: true # If true, changes reactive power of loads. If False, keeps the ones from the case file
   global_range: 0.4 # Range of the global scaling factor. used to set the lower bound of the scaling factor
   max_scaling_factor: 4.0 # Max upper bound of the global scaling factor
   step_size: 0.025 # Step size when finding the upper bound of the global scaling factor
   start_scaling_factor: 0.8 # Initial value of the global scaling factor
-  upper_limit : 1.68 # Global upper bound
-  lower_limit : 0.86 # Global lower bound 
-
+  
 topology_perturbation:
   k: 10 # Maximum number of components to drop in each perturbation
   n_topology_variants: 10 # Number of unique perturbed topologies per scenario


### PR DESCRIPTION
updated param handler to include "correlated_scaler"
load functions to perform pglearn load perturbations (not from aggregated load profile, not time dependent)
updated default.yaml to include upper and lower limits for these load perturbations
tested data generation for 2 grids